### PR TITLE
Replace NA values without tidyr

### DIFF
--- a/R/nma.R
+++ b/R/nma.R
@@ -1263,7 +1263,8 @@ nma.fit <- function(ipd_x, ipd_y,
                          }))
       agd_arm_ncat <- rowSums(agd_arm_cat > 0)
       # Replace missing category counts with 0 (these will drop out of the likelihood)
-      agd_arm_r <- tidyr::replace_na(agd_arm_y$.r, 0)
+      agd_arm_r <- agd_arm_y$.r
+      agd_arm_r[is.na(agd_arm_r)] <- 0
       agd_arm_n <- rowSums(agd_arm_y$.r, na.rm = TRUE)
     }
 


### PR DESCRIPTION
Using `tidyr::replace_na()` on a matrix does not appear to work anymore in tidyr 1.2.0. This base R alternative should fix this.

For example, the first `nma()` call in the Plaque psoriasis HTA report example results in the error `Stan does not support NA (in agd_arm_r) in data`:

```R
library(multinma)

pso_net <- set_agd_arm(hta_psoriasis, 
                       study = paste(studyc, year), 
                       trt = trtc, 
                       r = multi(r0 = sample_size - rowSums(cbind(PASI50, PASI75, PASI90), na.rm = TRUE), 
                                 PASI50, PASI75, PASI90,
                                 inclusive = FALSE, 
                                 type = "ordered"))

pso_fit_FE <- nma(pso_net, 
                  trt_effects = "fixed",
                  link = "probit",
                  prior_intercept = normal(scale = 100),
                  prior_trt = normal(scale = 10),
                  prior_aux = flat())
```