### PR TITLE
Fix contrast-based aggregate data resdev names

### DIFF
--- a/R/nma.R
+++ b/R/nma.R
@@ -735,7 +735,7 @@ nma <- function(network,
   # Labels for log_lik, resdev (only one entry per AgD contrast study)
   dev_labels <- c(ipd_data_labels,
                   agd_arm_data_labels,
-                  if (has_agd_contrast(network)) dat_agd_contrast_bl$.study else NULL)
+                  if (has_agd_contrast(network)) as.character(dat_agd_contrast_bl$.study) else NULL)
 
   fnames_oi[grepl("^log_lik\\[[0-9]+\\]$", fnames_oi)] <- paste0("log_lik[", dev_labels, "]")
   fnames_oi[grepl("^resdev\\[[0-9]+\\]$", fnames_oi)] <- paste0("resdev[", dev_labels, "]")


### PR DESCRIPTION
In a model with only contrast-based aggregate data, study names are incorrectly converted to integers when setting the `resdev` names in `fnames_oi`. This happens because the `.study` column is a factor, which is converted into an integer vector when concatenating with `NULL`. This PR proposes to convert to a character vector, which can be safely concatenated with `NULL`.

This causes the labels in DIC plots to appear as seemingly random integers, instead of the study names. 