### PR TITLE
Fix `multi()` parameter documentation

### DIFF
--- a/R/nma_data.R
+++ b/R/nma_data.R
@@ -1009,7 +1009,8 @@ combine_network <- function(..., trt_ref) {
 #' @param ... Two or more numeric columns (or vectors) of category counts.
 #'   Argument names (optional) will be used to label the categories.
 #' @param inclusive Logical, are ordered category counts inclusive (`TRUE`) or
-#'   exclusive (`FALSE`)? Default `FALSE`. Only used when `ordered = TRUE`. See details.
+#'   exclusive (`FALSE`)? Default `FALSE`. Only used when `type = "ordered"`.
+#'   See details.
 #' @param type String, indicating whether categories are `"ordered"` or
 #'   `"competing"`. Currently only ordered categorical outcomes are supported by
 #'   the modelling functions in this package.

--- a/man/multi.Rd
+++ b/man/multi.Rd
@@ -11,7 +11,8 @@ multi(..., inclusive = FALSE, type = c("ordered", "competing"))
 Argument names (optional) will be used to label the categories.}
 
 \item{inclusive}{Logical, are ordered category counts inclusive (\code{TRUE}) or
-exclusive (\code{FALSE})? Default \code{FALSE}. Only used when \code{ordered = TRUE}. See details.}
+exclusive (\code{FALSE})? Default \code{FALSE}. Only used when \code{type = "ordered"}.
+See details.}
 
 \item{type}{String, indicating whether categories are \code{"ordered"} or
 \code{"competing"}. Currently only ordered categorical outcomes are supported by


### PR DESCRIPTION
Refer to `type` instead of the non-existent `ordered` parameter in the documentation of the `inclusive` parameter of `multi()`.