### PR TITLE
Replace deprecated array syntax

### DIFF
--- a/inst/stan/include/data_common.stan
+++ b/inst/stan/include/data_common.stan
@@ -79,8 +79,8 @@ real<lower=0> prior_reg_df;
 
 // -- class effects model --
 int<lower=0, upper=1> class_effects; // Flag for whether an exchangeable class model is used (1) or not (0)
-int<lower=0> which_CE[class_effects ? nt-1 : 0]; // Class ID for each treatment (0 for no class effect)
-int<lower=0> which_CE_sd[class_effects ? nt-1 : 0]; // Design vector for class standard deviations
+array[class_effects ? nt-1 : 0] int<lower=0> which_CE; // Class ID for each treatment (0 for no class effect)
+array[class_effects ? nt-1 : 0] int<lower=0> which_CE_sd; // Design vector for class standard deviations
 
 int<lower=0,upper=3> prior_class_mean_dist; // Prior specifications for class means
 real prior_class_mean_location;


### PR DESCRIPTION
This PR just replaces a couple of stray usages of deprecated array syntax. Thanks!